### PR TITLE
Improve logging extension interface

### DIFF
--- a/Assets/Prefabs/ObjectLoggerManager.prefab
+++ b/Assets/Prefabs/ObjectLoggerManager.prefab
@@ -44,4 +44,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: d53ef46bd63694748b74807cc36ef7c8, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  _loggers: []
+  _loggingEnabled: 1
+  _combatEnabled: 1
+  _generalEnabled: 1
+  _networkEnabled: 1
+  _stateEnabled: 1

--- a/Assets/Scripts/Core/Logging/ObjectLoggerManager.cs
+++ b/Assets/Scripts/Core/Logging/ObjectLoggerManager.cs
@@ -3,48 +3,26 @@ using UnityEngine;
 namespace UBT.Logging
 {
     /// <summary>
-    /// Attach this to a GameObject to enable or disable ObjectLogger log methods
-    /// during play mode.
+    /// Attach this to a GameObject to enable or disable ObjectLogger log
+    /// categories during play mode.
     /// </summary>
     public class ObjectLoggerManager : MonoBehaviour
     {
-        [SerializeField] private LoggerStatus[] _loggers;
+        [SerializeField] private bool _loggingEnabled;
+        [SerializeField] private bool _combatEnabled;
+        [SerializeField] private bool _generalEnabled;
+        [SerializeField] private bool _networkEnabled;
+        [SerializeField] private bool _stateEnabled;
 
-        [System.Serializable]
-        public class LoggerStatus
-        {
-            public string Logger;
-            public bool Enabled;
 
-            public LoggerStatus(string logger, bool enabled)
-            {
-                Logger = logger;
-                Enabled = enabled;
-            }
-        }
-
-        private void Awake()
-        {
-            _loggers = new LoggerStatus[ObjectLogger.Loggers.Length];
-        }
-
-        private void OnEnable()
-        {
-            var length = Mathf.Min(ObjectLogger.Loggers.Length, _loggers.Length);
-            for (var i = 0; i < length; i++)
-            {
-                var logger = ObjectLogger.Loggers[i];
-                _loggers[i] = new(logger.Category, logger.Enabled);
-            }
-        }
 
         private void OnValidate()
         {
-            var length = Mathf.Min(ObjectLogger.Loggers.Length, _loggers.Length);
-            for (var i = 0; i < length; i++)
-            {
-                ObjectLogger.Loggers[i].Enabled = _loggers[i].Enabled;
-            }
+            ObjectLogger.Enabled = _loggingEnabled;
+            Category.CombatEnabled = _combatEnabled;
+            Category.GeneralEnabled = _generalEnabled;
+            Category.NetworkEnabled = _networkEnabled;
+            Category.StateEnabled = _stateEnabled;
         }
     }
 }


### PR DESCRIPTION
It now extends UnityEngine.Object to provide these methods:

* Log()
* LogWarning()
* LogError()

Each of those may be called directly with a message, or pass no arguments to return a Category struct, which contains methods for each logging category. This makes it easy to discover the available categories with your IDE's code completion.